### PR TITLE
feat: Implement auto refetch `value` on cache expiry

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.words": [
+        "refetchable",
+        "refetched"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![npm](https://img.shields.io/npm/v/run-cache?colorA=000000&colorB=ff98a2
+)](https://www.npmjs.com/package/run-cache)
+
 # RunCache
 
 `RunCache` is a dependency nil, light-weight in-memory caching library for JavaScript and TypeScript that allows you to cache `string` values with optional time-to-live (TTL) settings. It also supports caching values generated from asynchronous functions and provides methods for refetching and managing cached data.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![npm](https://img.shields.io/npm/v/run-cache?colorA=000000&colorB=ff98a2
-)](https://www.npmjs.com/package/run-cache)
+[![npm](https://img.shields.io/npm/v/run-cache?colorA=000000&colorB=ff98a2)](https://www.npmjs.com/package/run-cache)
 
 # RunCache
 

--- a/README.md
+++ b/README.md
@@ -21,29 +21,68 @@ npm install run-cache
 
 ## Usage
 
-```js
+#### Import library 
+```ts
 import { RunCache } from "run-cache";
+```
 
-// Set a cache value with 60s ttl
-RunCache.set("sample_key_1", "sample_value_1", 60000);
-
-// Set a cache value with function definition to fetch the value later
-RunCache.setWithSourceFn("sample_key_2", () => {
-  return Promise.resolve("sample_value_2");
+#### Set cache
+```ts
+// Set a cache value
+RunCache.set({
+  key: "Key", 
+  value: "Value",
 });
 
-// Refetch the cache value (This will call the above function and update the cache value)
-await RunCache.refetch("sample_key_2");
+// Set a cache value with 60s ttl
+RunCache.set({
+  key: "Key", 
+  value: "Value", 
+  ttl: 60000 // in milliseconds
+});
 
-// Get a value for a given cache key
-const value = RunCache.get("sample_key_1");
+// Set a cache value with function to fetch the value later
+RunCache.setWithSourceFn({
+  key: "Key", 
+  sourceFn: () => { return Promise.resolve("Value") }
+});
 
+/* 
+  Additionally set `autoRefetch: true` with a `ttl` value, this makes it auto-refetch the value on expiry when consumer tries to call `get` on this key
+*/
+RunCache.setWithSourceFn({
+  key: "Key", 
+  sourceFn: () => { return Promise.resolve("Value") }
+  autoRefetch: true,
+  ttl: 10000,
+});
+```
+
+#### Refetch values
+
+```ts
+// Refetch the cache value (Only works if the key is set with a sourceFn)
+await RunCache.refetch("Key");
+```
+
+#### Get cache
+
+```ts
+// Get a value for a given cache key, will refetch value automatically if `sourceFn` is provided and `autoRefetch: true`
+const value = await RunCache.get("Key");
+```
+
+#### Delete cache
+```ts
 // Delete a specific cache key
-RunCache.delete("sample_key_1");
+RunCache.delete("Key");
 
 // Delete all cache keys
 RunCache.deleteAll();
+```
 
-// Returns a boolean based on existence of the given cache key
-const hasCache = RunCache.has("sample_key_1");
+#### Check existence of cache
+```ts
+// Returns a boolean, expired cache returns `false` even if they're refetchable
+const hasCache = RunCache.has("Key");
 ```

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
-// jest.config.js
 export default {
   preset: "ts-jest",
   testEnvironment: "node",

--- a/src/run-cache.test.ts
+++ b/src/run-cache.test.ts
@@ -7,17 +7,23 @@ describe("RunCache", () => {
 
   describe("set()", () => {
     it("should throw an error if the cache key or value is empty", () => {
-      expect(() => RunCache.set("", "value1")).toThrow("Empty key");
-      expect(() => RunCache.set("key1", "")).toThrow("Empty value");
+      expect(() => RunCache.set({ key: "", value: "value1" })).toThrow(
+        "Empty key",
+      );
+      expect(() => RunCache.set({ key: "key1", value: "" })).toThrow(
+        "Empty value",
+      );
     });
 
     it("should return true if the cache value set successfully", () => {
-      expect(RunCache.set("key1", "value1")).toBe(true);
+      expect(RunCache.set({ key: "key1", value: "value1" })).toBe(true);
     });
 
-    it("should return true if the cache set with a ttl and ttl is functioning properly", () => {
-      expect(RunCache.set("key2", "value2", 100)).toBe(true);
-      expect(RunCache.get("key2")).toBe("value2");
+    it("should return true if the cache set with a ttl and ttl is functioning properly", async () => {
+      expect(RunCache.set({ key: "key2", value: "value2", ttl: 100 })).toBe(
+        true,
+      );
+      expect(await RunCache.get("key2")).toBe("value2");
 
       // Wait for the TTL to expire
       setTimeout(() => {
@@ -27,17 +33,17 @@ describe("RunCache", () => {
   });
 
   describe("get()", () => {
-    it("should return undefined if the key is empty", () => {
-      expect(RunCache.get("")).toBeUndefined();
+    it("should return undefined if the key is empty", async () => {
+      expect(await RunCache.get("")).toBeUndefined();
     });
 
-    it("should return undefined if the key is not found", () => {
-      expect(RunCache.get("key1")).toBeUndefined();
+    it("should return undefined if the key is not found", async () => {
+      expect(await RunCache.get("key1")).toBeUndefined();
     });
 
-    it("should return the value successfully", () => {
-      RunCache.set("key1", "value1");
-      expect(RunCache.get("key1")).toBe("value1");
+    it("should return the value successfully", async () => {
+      RunCache.set({ key: "key1", value: "value1" });
+      expect(await RunCache.get("key1")).toBe("value1");
     });
   });
 
@@ -46,26 +52,26 @@ describe("RunCache", () => {
       expect(RunCache.delete("nonExistentKey")).toBe(false);
     });
 
-    it("should return true if the value is successfully deleted", () => {
-      RunCache.set("key1", "value1");
+    it("should return true if the value is successfully deleted", async () => {
+      RunCache.set({ key: "key1", value: "value1" });
       expect(RunCache.delete("key1")).toBe(true);
-      expect(RunCache.get("key1")).toBeUndefined();
+      expect(await RunCache.get("key1")).toBeUndefined();
     });
   });
 
   describe("deleteAll()", () => {
-    it("should clear all values", () => {
-      RunCache.set("key1", "value1");
-      RunCache.set("key2", "value2");
+    it("should clear all values", async () => {
+      RunCache.set({ key: "key1", value: "value1" });
+      RunCache.set({ key: "key2", value: "value2" });
       RunCache.deleteAll();
-      expect(RunCache.get("key1")).toBeUndefined();
-      expect(RunCache.get("key2")).toBeUndefined();
+      expect(await RunCache.get("key1")).toBeUndefined();
+      expect(await RunCache.get("key2")).toBeUndefined();
     });
   });
 
   describe("has()", () => {
     it("should return true if the key exists", () => {
-      RunCache.set("key1", "value1");
+      RunCache.set({ key: "key1", value: "value1" });
       expect(RunCache.has("key1")).toBe(true);
     });
 
@@ -74,7 +80,7 @@ describe("RunCache", () => {
     });
 
     it("should return false after ttl expiry", () => {
-      RunCache.set("key2", "value2", 50); // Set TTL to 50ms
+      RunCache.set({ key: "key2", value: "value2", ttl: 50 }); // Set TTL to 50ms
       expect(RunCache.has("key2")).toBe(true);
 
       // Wait for the TTL to expire
@@ -89,21 +95,27 @@ describe("RunCache", () => {
       let sourceFn = async () => {
         throw Error("Unexpected Error");
       };
-      expect(RunCache.setWithSourceFn("key1", sourceFn)).rejects.toThrow(
-        "Source function failed",
-      );
+      expect(
+        RunCache.setWithSourceFn({
+          key: "key1",
+          sourceFn,
+        }),
+      ).rejects.toThrow("Source function failed");
     });
 
     it("should be able to set a value with source function successfully", async () => {
       const sourceFn = async () => "dynamicValue";
-      await RunCache.setWithSourceFn("key2", sourceFn);
-      expect(RunCache.get("key2")).toBe('"dynamicValue"');
+      await RunCache.setWithSourceFn({
+        key: "key2",
+        sourceFn,
+      });
+      expect(await RunCache.get("key2")).toBe('"dynamicValue"');
     });
   });
 
   describe("refetch()", () => {
     it("should throw an error if refetch is called on a key having no source function", async () => {
-      RunCache.set("key2", "value2");
+      RunCache.set({ key: "key2", value: "value2" });
       await expect(RunCache.refetch("key2")).rejects.toThrow(
         "No source function found",
       );
@@ -119,7 +131,7 @@ describe("RunCache", () => {
           return "SomeValue";
         }
       };
-      await RunCache.setWithSourceFn("key3", sourceFn);
+      await RunCache.setWithSourceFn({ key: "key3", sourceFn });
 
       // Make source function to fail
       breaker = true;
@@ -137,14 +149,14 @@ describe("RunCache", () => {
       let dynamicValue = "initialValue";
       const sourceFn = async () => dynamicValue;
 
-      await RunCache.setWithSourceFn("key1", sourceFn);
-      expect(RunCache.get("key1")).toBe('"initialValue"');
+      await RunCache.setWithSourceFn({ key: "key1", sourceFn });
+      expect(await RunCache.get("key1")).toBe('"initialValue"');
 
       // Update what's being returned in the source function
       dynamicValue = "updatedValue";
 
       await RunCache.refetch("key1");
-      expect(RunCache.get("key1")).toBe('"updatedValue"');
+      expect(await RunCache.get("key1")).toBe('"updatedValue"');
     });
   });
 });

--- a/src/run-cache.test.ts
+++ b/src/run-cache.test.ts
@@ -80,8 +80,6 @@ describe("RunCache", () => {
       // Wait for the TTL to expire
       await sleep(150);
 
-      console.log('await RunCache.get("key2")', await RunCache.get("key2"));
-
       expect(await RunCache.get("key2")).toBe(JSON.stringify("updatedValue"));
     });
 

--- a/src/run-cache.ts
+++ b/src/run-cache.ts
@@ -78,6 +78,10 @@ class RunCache {
     ttl?: number;
     autoRefetch?: boolean;
   }): Promise<void> {
+    if (!ttl && autoRefetch) {
+      throw Error("`autoRefetch` is not allowed without `ttl`");
+    }
+
     try {
       const value = await sourceFn.call(this);
 
@@ -95,7 +99,7 @@ class RunCache {
   }
 
   /**
-   * Refetches the cached value using the stored source function and updates the cache with the new value.
+   * Refetch the cached value using the stored source function and updates the cache with the new value.
    *
    * @param {string} key - The cache key.
    * @param {number} [ttl] - Optional time-to-live in milliseconds for the updated value.
@@ -150,12 +154,7 @@ class RunCache {
       return cached.value;
     }
 
-    if (!cached.sourceFn) {
-      RunCache.cache.delete(key);
-      return undefined;
-    }
-
-    if (!cached.autoRefetch) {
+    if (cached.sourceFn === undefined || !cached.autoRefetch) {
       RunCache.cache.delete(key);
       return undefined;
     }

--- a/src/run-cache.ts
+++ b/src/run-cache.ts
@@ -19,13 +19,15 @@ class RunCache {
   }
 
   /**
-   * Adds a value to the cache with an optional TTL.
+   * Sets a value in the cache with an optional time-to-live (TTL) value.
+   * This method stores the value associated with the given key and tracks the creation and update timestamps.
    *
-   * @param {string} key - The cache key.
-   * @param {string} value - The value to cache.
-   * @param {number} [ttl] - Optional time-to-live in milliseconds.
-   * @returns {boolean} - The state of the operation
-   * @throws Will throw an error if the key or value is empty
+   * @param {Object} params - Parameters for setting the cache entry.
+   * @param {string} params.key - The key under which the value will be stored in the cache.
+   * @param {string} params.value - The string value to be stored in the cache.
+   * @param {number} [params.ttl] - Optional. Time-to-live for the cached entry in milliseconds. If not specified, the entry will not automatically expire.
+   * @returns {boolean} Returns `true` if the value was successfully set in the cache.
+   * @throws {Error} Throws an error if the `key` or `value` is empty.
    */
   static set({
     key,
@@ -102,7 +104,6 @@ class RunCache {
    * Refetch the cached value using the stored source function and updates the cache with the new value.
    *
    * @param {string} key - The cache key.
-   * @param {number} [ttl] - Optional time-to-live in milliseconds for the updated value.
    * @returns {Promise<boolean>} A promise that resolves to a boolean representing the execution state of the request.
    * @throws Will throw an error if the source function fails.
    */
@@ -134,10 +135,12 @@ class RunCache {
   }
 
   /**
-   * Retrieves the cached value associated with the given key if it exists and has not expired.
+   * Retrieves a value from the cache by key. If the cached value has expired, it will be removed from the cache unless
+   * `autoRefetch` is enabled with an associated `sourceFn`, in which case the value will be refetched automatically.
    *
-   * @param {string} key - The cache key.
-   * @returns {string | undefined} The cached value, or undefined if not found or expired.
+   * @async
+   * @param {string} key - The key of the cache entry to retrieve.
+   * @returns {Promise<string | undefined>} A promise that resolves to the cached value if found and not expired, or `undefined` if the key is not found or the value has expired.
    */
   static async get(key: string): Promise<string | undefined> {
     if (!key) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": ".",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": ["ES2015"]
   }
 }


### PR DESCRIPTION
- Introduced a a new param `Value auto refetch on` into `setWithSourceFn` function.
- Refactored param structure of few functions to objects.
- Update `get` function to auto-refetch values when the cache is expired while `autoRefetch: true`.

Fixes #1