### PR TITLE
chore: Bump `npm` version

### DIFF
--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -1,4 +1,4 @@
-name: Run Build
+name: Build
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Run Build
 
 on:
   push:
@@ -19,5 +19,5 @@ jobs:
           node-version: "18"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Test
-        run: npm test
+      - name: Build
+        run: npm run build

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Tests
 
 on:
   push:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,5 +19,8 @@ jobs:
           node-version: "18"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Test
         run: npm test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![npm](https://img.shields.io/npm/v/run-cache?colorA=000000&colorB=ff98a2)](https://www.npmjs.com/package/run-cache)
+![npm-version](https://img.shields.io/npm/v/run-cache?style=plastic)
+![license](https://img.shields.io/github/license/helloscoopa/run-cache?style=plastic)
+![ci-build](https://img.shields.io/github/actions/workflow/status/helloscoopa/run-cache/run-build.yml?style=plastic)
+![ci-tests](https://img.shields.io/github/actions/workflow/status/helloscoopa/run-cache/run-tests.yml?label=tests&style=plastic)
 
 # Run~time~Cache
 
@@ -9,6 +12,7 @@ RunCache is a dependency nil, light-weight in-memory caching library for JavaScr
 - **In-memory caching** with optional TTL (time-to-live).
 - **Asynchronous source functions** for fetching and caching dynamic data.
 - **Refetch functionality** to update cache values using stored source functions.
+- **Events** to get know when cache expires or being refetched.
 - **Easy interface** for managing cached data: set, get, delete and check existence.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-![npm-version](https://img.shields.io/npm/v/run-cache?style=plastic)
-![license](https://img.shields.io/github/license/helloscoopa/run-cache?style=plastic)
-![ci-build](https://img.shields.io/github/actions/workflow/status/helloscoopa/run-cache/run-build.yml?style=plastic)
-![ci-tests](https://img.shields.io/github/actions/workflow/status/helloscoopa/run-cache/run-tests.yml?label=tests&style=plastic)
+![npm-version](https://img.shields.io/npm/v/run-cache)
+![commits-since](https://img.shields.io/github/commits-since/helloscoopa/run-cache/latest/main)
+![license](https://img.shields.io/github/license/helloscoopa/run-cache)
+![ci-build](https://img.shields.io/github/actions/workflow/status/helloscoopa/run-cache/run-build.yml?label=build)
+![ci-tests](https://img.shields.io/github/actions/workflow/status/helloscoopa/run-cache/run-tests.yml?label=tests)
 
 # Run~time~Cache
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "run-cache",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "RunCache is a dependency nil, light-weight in-memory caching library for JavaScript and TypeScript that allows you to cache `string` values with optional time-to-live (TTL) settings. It also supports caching values generated from asynchronous functions and provides methods to refetch them on demand.",
   "main": "dist/run-cache.js",
   "types": "dist/run-cache.d.ts",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a GitHub Actions workflow for automated builds of the Node.js application.
	- Enhanced `RunCache` library with events notifying users of cache expiration or refetching.

- **Bug Fixes**
	- Streamlined testing workflow by removing unnecessary steps for dependency installation and build.

- **Documentation**
	- Added badges to the README for project status and metrics.
	- Expanded functionality description of the `RunCache` library. 

- **Chores**
	- Updated the version number of the `run-cache` library from 1.2.2 to 1.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->