### PR TITLE
feat: Upgrade event callbacks into `EventEmitter`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,5 +19,8 @@ jobs:
           node-version: "18"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Build
         run: npm run build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["refetchable", "refetched"]
+  "cSpell.words": ["refetchable", "refetched", "refetches"]
 }

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ RunCache.delete("Key");
 RunCache.deleteAll();
 ```
 
-#### Check existence of a specific cache
+#### Check the existence of a specific cache
 
 ```ts
 // Returns a boolean, expired cache returns `false` even if they're refetchable

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ const value = await RunCache.get("Key");
 RunCache.delete("Key");
 
 // Delete all cache keys
-RunCache.deleteAll();
+RunCache.flush();
 ```
 
 #### Check the existence of a specific cache
@@ -142,14 +142,6 @@ const hasCache = RunCache.has("Key");
 #### Clear event listeners
 
 ```ts
-await RunCache.set({
-  key: "Key",
-  ttl: 10000,
-  sourceFn: () => {
-    return Promise.resolve("Value");
-  },
-});
-
 // Clear all listeners
 RunCache.clearEventListeners();
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Run~time~Cache
 
-RunCache is a dependency nil, light-weight in-memory caching library for JavaScript and TypeScript that allows you to cache `string` values with optional time-to-live (TTL) settings. It also supports caching values generated from asynchronous functions and provides methods to refetch them on demand.
+RunCache is a dependency nil, lightweight runtime caching library for JavaScript and TypeScript that allows you to cache `string` values with optional time-to-live (TTL) settings. It also supports caching values generated from asynchronous functions and provides methods to refetch them on demand.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install run-cache
 import { RunCache } from "run-cache";
 ```
 
-#### Set cache:
+#### Set cache
 
 ```ts
 // Set a cache value
@@ -74,32 +74,46 @@ await RunCache.set({
 */
 import { EventParam } from "run-cache";
 
+// Event of all expiries
+RunCache.onExpiry((cache: EventParam) => {
+  console.log(`Cache of key '${cache.key}' has been expired`);
+})
+
+// Event of a specific key expiry
+RunCache.onExpiry('Key', (cache: EventParam) => {
+  console.log(`Cache of key '${cache.key}' has been expired`);
+})
+
 await RunCache.set({
   key: "Key",
-  ttl: 10000,
-  onExpiry: (cache: EventParam) => {
-    console.log(`Cache of key '${cache.key}' has been expired`);
-  }
+  ttl: 10000
+})
+
+// Event of all refetches
+RunCache.onRefetch((cache: EventParam) => {
+  console.log(`Cache of key '${cache.key}' has been refetched`);
+})
+
+// Event of a specific key refetch
+RunCache.onKeyRefetch('Key', (cache: EventParam) => {
+  console.log(`Cache of key '${cache.key}' has been refetched`);
 })
 
 await RunCache.set({
   key: "Key",
   ttl: 10000,
-  sourceFn: () => { return Promise.resolve("Value") },
-  onRefetch: (cache: EventParam) => {
-    console.log(`Cache of key '${cache.key}' has been refetched`);
-  }
+  sourceFn: () => { return Promise.resolve("Value") }
 })
 ```
 
-#### Refetch cache:
+#### Refetch cache
 
 ```ts
 // Refetch the cache value (Only works if the key is set with a sourceFn)
 await RunCache.refetch("Key");
 ```
 
-#### Get cache:
+#### Get cache
 
 ```ts
 /* 
@@ -109,7 +123,7 @@ await RunCache.refetch("Key");
 const value = await RunCache.get("Key");
 ```
 
-#### Delete cache:
+#### Delete cache
 
 ```ts
 // Delete a specific cache key
@@ -119,9 +133,35 @@ RunCache.delete("Key");
 RunCache.deleteAll();
 ```
 
-#### Check existence of a specific cache:
+#### Check existence of a specific cache
 
 ```ts
 // Returns a boolean, expired cache returns `false` even if they're refetchable
 const hasCache = RunCache.has("Key");
+```
+
+#### Clear event listeners
+
+```ts
+await RunCache.set({
+  key: "Key",
+  ttl: 10000,
+  sourceFn: () => {
+    return Promise.resolve("Value");
+  },
+});
+
+// Clear all listeners
+RunCache.clearEventListeners();
+
+// Clear specific event listeners
+RunCache.clearEventListeners({
+  event: "expiry",
+});
+
+// Clear specific event key listeners
+RunCache.clearEventListeners({
+  event: "expiry",
+  key: "Key",
+});
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Run~time~Cache
 
-RunCache is a dependency-free, lightweight runtime caching library for JavaScript and TypeScript that allows you to cache `string` values with optional time-to-live (TTL) settings. It also supports caching values generated from sync/async functions and provide methods to refetch them on expiry or on demand; with set of events to keep track of the state of the cache.
+RunCache is a dependency-free, lightweight runtime caching library for JavaScript and TypeScript that allows you to cache `string` values with optional time-to-live (TTL) settings. It also supports caching values generated from sync/async functions and provide methods to refetch them on expiry or on demand; with a set of events to keep track of the state of the cache.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ import { EventParam } from "run-cache";
 await RunCache.set({
   key: "Key",
   ttl: 10000,
-  onExpiry: async (cache: EventParam) => {
+  onExpiry: (cache: EventParam) => {
     console.log(`Cache of key '${cache.key}' has been expired`);
   }
 })
@@ -85,8 +85,8 @@ await RunCache.set({
 await RunCache.set({
   key: "Key",
   ttl: 10000,
-  sourceFn: () => { return Promise.resolve("Value") }
-  onRefetch: async (cache: EventParam) => {
+  sourceFn: () => { return Promise.resolve("Value") },
+  onRefetch: (cache: EventParam) => {
     console.log(`Cache of key '${cache.key}' has been refetched`);
   }
 })

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Run~time~Cache
 
-RunCache is a dependency nil, lightweight runtime caching library for JavaScript and TypeScript that allows you to cache `string` values with optional time-to-live (TTL) settings. It also supports caching values generated from asynchronous functions and provides methods to refetch them on demand.
+RunCache is a dependency-free, lightweight runtime caching library for JavaScript and TypeScript that allows you to cache `string` values with optional time-to-live (TTL) settings. It also supports caching values generated from asynchronous functions and provides methods to refetch them on demand.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![license](https://img.shields.io/github/license/helloscoopa/run-cache)](https://github.com/helloscoopa/run-cache?tab=MIT-1-ov-file)
 [![ci-build](https://img.shields.io/github/actions/workflow/status/helloscoopa/run-cache/build.yml?label=build)](https://github.com/helloscoopa/run-cache/actions/workflows/build.yml)
 [![ci-tests](https://img.shields.io/github/actions/workflow/status/helloscoopa/run-cache/tests.yml?label=tests)](https://github.com/helloscoopa/run-cache/actions/workflows/tests.yml)
-[![commits-since](https://img.shields.io/github/commits-since/helloscoopa/run-cache/latest/main?color=yellow)](https://github.com/helloscoopa/run-cache/releases/latest)
 
 # Run~time~Cache
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 
 # Run~time~Cache
 
-RunCache is a dependency-free, lightweight runtime caching library for JavaScript and TypeScript that allows you to cache `string` values with optional time-to-live (TTL) settings. It also supports caching values generated from asynchronous functions and provides methods to refetch them on demand.
+RunCache is a dependency-free, lightweight runtime caching library for JavaScript and TypeScript that allows you to cache `string` values with optional time-to-live (TTL) settings. It also supports caching values generated from sync/async functions and provide methods to refetch them on expiry or on demand; with set of events to keep track of the state of the cache.
 
 ## Features
 
-- **In-memory caching** with optional TTL (time-to-live).
-- **Asynchronous source functions** for fetching and caching dynamic data.
-- **Refetch functionality** to update cache values using stored source functions.
-- **Events** to get know when cache expires or being refetched.
-- **Easy interface** for managing cached data: set, get, delete and check existence.
+- **Dependency-free:** Does not consume any external dependencies.
+- **In-memory caching:** A runtime cache that gives you quick access.
+- **Sync/async source functions:** Fetch dynamic data from user-defined functions.
+- **Events:** Get to know when cache expires, refetched or refetch fails.
+- **Intuitive SDK:** Clean interface to access data.
 
 ## Installation
 
@@ -67,7 +67,7 @@ await RunCache.set({
 });
 
 /*
-  Use a callback function to get know when your cache expires
+  Use a callback function to get to know when your cache expires
   or when its being refetched. The expiry is triggered only
   on demand, not automatically.
 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "run-cache",
-  "version": "1.2.2",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "run-cache",
-      "version": "1.2.2",
+      "version": "1.3.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",
+        "@types/uuid": "^10.0.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
-        "tsx": "^4.19.1"
+        "tsx": "^4.19.1",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1381,6 +1383,12 @@
       "version": "2.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -3705,6 +3713,19 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "dev": true,
@@ -4688,6 +4709,12 @@
     },
     "@types/stack-utils": {
       "version": "2.0.3",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true
     },
     "@types/yargs": {
@@ -6123,6 +6150,12 @@
         "escalade": "^3.1.2",
         "picocolors": "^1.0.1"
       }
+    },
+    "uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true
     },
     "v8-to-istanbul": {
       "version": "9.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",
+        "@types/node": "^22.5.5",
         "@types/uuid": "^10.0.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
@@ -1372,9 +1373,10 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.5.4",
+      "version": "22.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
+      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -4701,7 +4703,9 @@
       }
     },
     "@types/node": {
-      "version": "22.5.4",
+      "version": "22.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
+      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
       "dev": true,
       "requires": {
         "undici-types": "~6.19.2"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
+    "@types/uuid": "^10.0.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
-    "tsx": "^4.19.1"
+    "tsx": "^4.19.1",
+    "uuid": "^10.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
+    "@types/node": "^22.5.5",
     "@types/uuid": "^10.0.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
-    "@types/node": "^22.5.5",
     "@types/uuid": "^10.0.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "run-cache",
-  "version": "1.3.2",
-  "description": "RunCache is a dependency nil, light-weight in-memory caching library for JavaScript and TypeScript that allows you to cache `string` values with optional time-to-live (TTL) settings. It also supports caching values generated from asynchronous functions and provides methods to refetch them on demand.",
+  "version": "1.4.0",
+  "description": "RunCache is a dependency-free, light-weight in-memory caching library for JavaScript and TypeScript that allows you to cache `string` values with optional time-to-live (TTL) settings. It also supports caching values generated from asynchronous functions and provides methods to refetch them on demand.",
   "main": "dist/run-cache.js",
   "types": "dist/run-cache.d.ts",
   "scripts": {

--- a/src/run-cache.test.ts
+++ b/src/run-cache.test.ts
@@ -226,7 +226,7 @@ describe("RunCache", () => {
       expect(await RunCache.has(key)).toStrictEqual(true);
     });
 
-    it("should return false if the key exists", async () => {
+    it("should return false if the key does not exist", async () => {
       expect(await RunCache.has("NonExistentKey")).toStrictEqual(false);
     });
 
@@ -248,9 +248,7 @@ describe("RunCache", () => {
       const key = uuid();
 
       RunCache.set({ key, value: uuid() });
-      await expect(RunCache.refetch(key)).rejects.toThrow(
-        `No source function found for key: '${key}'`,
-      );
+      await expect(RunCache.refetch(key)).resolves.toStrictEqual(false);
     });
 
     it("should throw an error when the source function throws an error", async () => {
@@ -341,7 +339,7 @@ describe("RunCache", () => {
       const funcToBeExecutedOnExpiry = jest.fn(
         async (cacheState: EventParam) => {
           expect(cacheState.key).toStrictEqual(key);
-          expect(cacheState.value).toStrictEqual(JSON.stringify(value));
+          expect(cacheState.value).toStrictEqual(value);
           expect(cacheState.ttl).toStrictEqual(100);
         },
       );
@@ -351,7 +349,7 @@ describe("RunCache", () => {
 
       RunCache.set({
         key,
-        value: JSON.stringify(value),
+        value: value,
         ttl: 100,
       });
 

--- a/src/run-cache.test.ts
+++ b/src/run-cache.test.ts
@@ -1,4 +1,4 @@
-import { EventParam, RunCache } from "./run-cache";
+import { EVENT, EventParam, RunCache } from "./run-cache";
 import { v4 as uuid } from "uuid";
 
 async function sleep(ms: number): Promise<void> {
@@ -335,8 +335,6 @@ describe("RunCache", () => {
 
   describe("onExpire() and onKeyExpiry()", () => {
     it("should trigger after ttl expiry", async () => {
-      jest.useFakeTimers();
-
       const key = uuid();
       const value = uuid();
 
@@ -455,7 +453,9 @@ describe("RunCache", () => {
         autoRefetch: true,
       });
 
-      const eventsCleared = RunCache.clearEventListeners({ event: "expire" });
+      const eventsCleared = RunCache.clearEventListeners({
+        event: EVENT.EXPIRE,
+      });
       expect(eventsCleared).toBeTruthy();
 
       jest.advanceTimersByTime(101);
@@ -472,7 +472,7 @@ describe("RunCache", () => {
       const funcToBeExecutedOnRefetch = jest.fn();
       const funcToBeExecutedOnExpiry = jest.fn();
 
-      const sourceFn = jest.fn(() => "value");
+      const sourceFn = jest.fn(() => uuid());
 
       RunCache.onRefetch(funcToBeExecutedOnRefetch);
       RunCache.onKeyRefetch(key, funcToBeExecutedOnRefetch);
@@ -481,7 +481,7 @@ describe("RunCache", () => {
       RunCache.onKeyExpiry(key, funcToBeExecutedOnExpiry);
 
       const eventsCleared = RunCache.clearEventListeners({
-        event: "expire",
+        event: EVENT.EXPIRE,
         key,
       });
       expect(eventsCleared).toBeTruthy();

--- a/src/run-cache.test.ts
+++ b/src/run-cache.test.ts
@@ -81,7 +81,9 @@ describe("RunCache", () => {
         key,
         sourceFn,
       });
-      expect(await RunCache.get(key)).toStrictEqual(JSON.stringify(value));
+      await expect(RunCache.get(key)).resolves.toStrictEqual(
+        JSON.stringify(value),
+      );
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
     });
@@ -98,37 +100,43 @@ describe("RunCache", () => {
         ttl: 100,
         autoRefetch: true,
       });
-      expect(await RunCache.get(key)).toStrictEqual(JSON.stringify(value));
+      await expect(RunCache.get(key)).resolves.toStrictEqual(
+        JSON.stringify(value),
+      );
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
     });
 
     it("should return true if the cache value set successfully", async () => {
-      expect(await RunCache.set({ key: uuid(), value: uuid() })).toStrictEqual(
-        true,
-      );
+      await expect(
+        RunCache.set({ key: uuid(), value: uuid() }),
+      ).resolves.toStrictEqual(true);
     });
 
     it("should return true if the cache set with a ttl and ttl is functioning properly", async () => {
       const key = uuid();
       const value = uuid();
 
-      expect(await RunCache.set({ key, value, ttl: 100 })).toStrictEqual(true);
-      expect(await RunCache.get(key)).toStrictEqual(JSON.stringify(value));
+      await expect(
+        RunCache.set({ key, value, ttl: 100 }),
+      ).resolves.toStrictEqual(true);
+      await expect(RunCache.get(key)).resolves.toStrictEqual(
+        JSON.stringify(value),
+      );
 
       jest.advanceTimersByTime(101);
 
-      expect(await RunCache.get(key)).toBeUndefined();
+      await expect(RunCache.get(key)).resolves.toBeUndefined();
     });
   });
 
   describe("get()", () => {
     it("should return undefined if the key is empty", async () => {
-      expect(await RunCache.get("")).toBeUndefined();
+      await expect(RunCache.get("")).resolves.toBeUndefined();
     });
 
     it("should return undefined if the key is not found", async () => {
-      expect(await RunCache.get(uuid())).toBeUndefined();
+      await expect(RunCache.get(uuid())).resolves.toBeUndefined();
     });
 
     it("should return the value successfully if the cache is not expired", async () => {
@@ -143,7 +151,9 @@ describe("RunCache", () => {
         ttl: 100,
       });
 
-      expect(await RunCache.get(key)).toStrictEqual(JSON.stringify(value));
+      await expect(RunCache.get(key)).resolves.toStrictEqual(
+        JSON.stringify(value),
+      );
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
     });
@@ -163,7 +173,7 @@ describe("RunCache", () => {
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
 
-      expect(await RunCache.get(key)).toStrictEqual(
+      await expect(RunCache.get(key)).resolves.toStrictEqual(
         JSON.stringify(dynamicValue),
       );
 
@@ -171,7 +181,7 @@ describe("RunCache", () => {
 
       jest.advanceTimersByTime(101);
 
-      expect(await RunCache.get(key)).toStrictEqual(
+      await expect(RunCache.get(key)).resolves.toStrictEqual(
         JSON.stringify(dynamicValue),
       );
 
@@ -182,8 +192,10 @@ describe("RunCache", () => {
       const key = uuid();
       const value = uuid();
 
-      RunCache.set({ key, value });
-      expect(await RunCache.get(key)).toStrictEqual(JSON.stringify(value));
+      await RunCache.set({ key, value });
+      await expect(RunCache.get(key)).resolves.toStrictEqual(
+        JSON.stringify(value),
+      );
     });
   });
 
@@ -196,9 +208,9 @@ describe("RunCache", () => {
       const key = uuid();
       const value = uuid();
 
-      RunCache.set({ key, value });
+      await RunCache.set({ key, value });
       expect(RunCache.delete(key)).toStrictEqual(true);
-      expect(await RunCache.get(key)).toBeUndefined();
+      await expect(RunCache.get(key)).resolves.toBeUndefined();
     });
   });
 
@@ -209,11 +221,11 @@ describe("RunCache", () => {
       const value1 = uuid();
       const value2 = uuid();
 
-      RunCache.set({ key: key1, value: value1 });
-      RunCache.set({ key: key2, value: value2 });
+      await RunCache.set({ key: key1, value: value1 });
+      await RunCache.set({ key: key2, value: value2 });
       RunCache.flush();
-      expect(await RunCache.get(key1)).toBeUndefined();
-      expect(await RunCache.get(key2)).toBeUndefined();
+      await expect(RunCache.get(key1)).resolves.toBeUndefined();
+      await expect(RunCache.get(key2)).resolves.toBeUndefined();
     });
   });
 
@@ -222,24 +234,26 @@ describe("RunCache", () => {
       const key = uuid();
       const value = uuid();
 
-      RunCache.set({ key, value });
-      expect(await RunCache.has(key)).toStrictEqual(true);
+      await RunCache.set({ key, value });
+      await expect(RunCache.has(key)).resolves.toStrictEqual(true);
     });
 
     it("should return false if the key does not exist", async () => {
-      expect(await RunCache.has("NonExistentKey")).toStrictEqual(false);
+      await expect(RunCache.has("NonExistentKey")).resolves.toStrictEqual(
+        false,
+      );
     });
 
     it("should return false after ttl expiry", async () => {
       const key = uuid();
       const value = uuid();
 
-      RunCache.set({ key, value, ttl: 100 });
-      expect(await RunCache.has(key)).toStrictEqual(true);
+      await RunCache.set({ key, value, ttl: 100 });
+      await expect(RunCache.has(key)).resolves.toStrictEqual(true);
 
       jest.advanceTimersByTime(101);
 
-      expect(await RunCache.has(key)).toStrictEqual(false);
+      await expect(RunCache.has(key)).resolves.toStrictEqual(false);
     });
   });
 
@@ -247,7 +261,7 @@ describe("RunCache", () => {
     it("should resolve to false if refetch is called on a key having no source function", async () => {
       const key = uuid();
 
-      RunCache.set({ key, value: uuid() });
+      await RunCache.set({ key, value: uuid() });
       await expect(RunCache.refetch(key)).resolves.toStrictEqual(false);
     });
 
@@ -313,7 +327,7 @@ describe("RunCache", () => {
       const sourceFn = jest.fn(() => dynamicValue);
 
       await RunCache.set({ key, sourceFn });
-      expect(await RunCache.get(key)).toStrictEqual(
+      await expect(RunCache.get(key)).resolves.toStrictEqual(
         JSON.stringify(dynamicValue),
       );
 
@@ -325,7 +339,7 @@ describe("RunCache", () => {
 
       expect(sourceFn).toHaveBeenCalledTimes(2);
 
-      expect(await RunCache.get(key)).toStrictEqual(
+      await expect(RunCache.get(key)).resolves.toStrictEqual(
         JSON.stringify(dynamicValue),
       );
     });

--- a/src/run-cache.test.ts
+++ b/src/run-cache.test.ts
@@ -244,7 +244,7 @@ describe("RunCache", () => {
   });
 
   describe("refetch()", () => {
-    it("should throw an error if refetch is called on a key having no source function", async () => {
+    it("should resolve to false if refetch is called on a key having no source function", async () => {
       const key = uuid();
 
       RunCache.set({ key, value: uuid() });
@@ -339,7 +339,7 @@ describe("RunCache", () => {
       const funcToBeExecutedOnExpiry = jest.fn(
         async (cacheState: EventParam) => {
           expect(cacheState.key).toStrictEqual(key);
-          expect(cacheState.value).toStrictEqual(value);
+          expect(cacheState.value).toStrictEqual(JSON.stringify(value));
           expect(cacheState.ttl).toStrictEqual(100);
         },
       );

--- a/src/run-cache.test.ts
+++ b/src/run-cache.test.ts
@@ -369,10 +369,7 @@ describe("RunCache", () => {
 
   describe("onRefetch() and onKeyRefetch()", () => {
     it("should trigger on refetch", async () => {
-      jest.useFakeTimers();
-
       const key = uuid();
-
       let dynamicValue = uuid();
 
       const funcToBeExecutedOnRefetch = jest.fn((cacheState: EventParam) => {
@@ -406,8 +403,6 @@ describe("RunCache", () => {
 
   describe("onRefetchFailure() and onKeyRefetchFailure()", () => {
     it("should trigger if the sourceFn fails", async () => {
-      jest.useFakeTimers();
-
       const key = uuid();
       const value = uuid();
 
@@ -423,7 +418,7 @@ describe("RunCache", () => {
 
       const sourceFn = jest.fn(() => {
         if (breaker) {
-          throw Error();
+          throw Error("Simulated source function failure");
         } else {
           return uuid();
         }
@@ -490,7 +485,7 @@ describe("RunCache", () => {
       const funcToBeExecutedOnRefetch = jest.fn();
       const funcToBeExecutedOnExpiry = jest.fn();
 
-      const sourceFn = jest.fn(() => "value");
+      const sourceFn = jest.fn(() => uuid());
 
       RunCache.onRefetch(funcToBeExecutedOnRefetch);
       RunCache.onKeyRefetch(key, funcToBeExecutedOnRefetch);

--- a/src/run-cache.test.ts
+++ b/src/run-cache.test.ts
@@ -77,9 +77,7 @@ describe("RunCache", () => {
         key,
         sourceFn,
       });
-      await expect(RunCache.get(key)).resolves.toStrictEqual(
-        JSON.stringify(value),
-      );
+      await expect(RunCache.get(key)).resolves.toStrictEqual(value);
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
     });
@@ -96,9 +94,7 @@ describe("RunCache", () => {
         ttl: 100,
         autoRefetch: true,
       });
-      await expect(RunCache.get(key)).resolves.toStrictEqual(
-        JSON.stringify(value),
-      );
+      await expect(RunCache.get(key)).resolves.toStrictEqual(value);
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
     });
@@ -116,9 +112,7 @@ describe("RunCache", () => {
       await expect(
         RunCache.set({ key, value, ttl: 100 }),
       ).resolves.toStrictEqual(true);
-      await expect(RunCache.get(key)).resolves.toStrictEqual(
-        JSON.stringify(value),
-      );
+      await expect(RunCache.get(key)).resolves.toStrictEqual(value);
 
       jest.advanceTimersByTime(101);
 
@@ -147,9 +141,7 @@ describe("RunCache", () => {
         ttl: 100,
       });
 
-      await expect(RunCache.get(key)).resolves.toStrictEqual(
-        JSON.stringify(value),
-      );
+      await expect(RunCache.get(key)).resolves.toStrictEqual(value);
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
     });
@@ -169,17 +161,13 @@ describe("RunCache", () => {
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
 
-      await expect(RunCache.get(key)).resolves.toStrictEqual(
-        JSON.stringify(dynamicValue),
-      );
+      await expect(RunCache.get(key)).resolves.toStrictEqual(dynamicValue);
 
       dynamicValue = uuid();
 
       jest.advanceTimersByTime(101);
 
-      await expect(RunCache.get(key)).resolves.toStrictEqual(
-        JSON.stringify(dynamicValue),
-      );
+      await expect(RunCache.get(key)).resolves.toStrictEqual(dynamicValue);
 
       expect(sourceFn).toHaveBeenCalledTimes(2);
     });
@@ -189,9 +177,7 @@ describe("RunCache", () => {
       const value = uuid();
 
       await RunCache.set({ key, value });
-      await expect(RunCache.get(key)).resolves.toStrictEqual(
-        JSON.stringify(value),
-      );
+      await expect(RunCache.get(key)).resolves.toStrictEqual(value);
     });
   });
 
@@ -320,9 +306,7 @@ describe("RunCache", () => {
       const sourceFn = jest.fn(() => dynamicValue);
 
       await RunCache.set({ key, sourceFn });
-      await expect(RunCache.get(key)).resolves.toStrictEqual(
-        JSON.stringify(dynamicValue),
-      );
+      await expect(RunCache.get(key)).resolves.toStrictEqual(dynamicValue);
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
 
@@ -332,9 +316,7 @@ describe("RunCache", () => {
 
       expect(sourceFn).toHaveBeenCalledTimes(2);
 
-      await expect(RunCache.get(key)).resolves.toStrictEqual(
-        JSON.stringify(dynamicValue),
-      );
+      await expect(RunCache.get(key)).resolves.toStrictEqual(dynamicValue);
     });
   });
 
@@ -346,7 +328,7 @@ describe("RunCache", () => {
       const funcToBeExecutedOnExpiry = jest.fn(
         async (cacheState: EventParam) => {
           expect(cacheState.key).toStrictEqual(key);
-          expect(cacheState.value).toStrictEqual(JSON.stringify(value));
+          expect(cacheState.value).toStrictEqual(value);
           expect(cacheState.ttl).toStrictEqual(100);
         },
       );
@@ -374,7 +356,7 @@ describe("RunCache", () => {
 
       const funcToBeExecutedOnRefetch = jest.fn((cacheState: EventParam) => {
         expect(cacheState.key).toStrictEqual(key);
-        expect(cacheState.value).toStrictEqual(JSON.stringify(dynamicValue));
+        expect(cacheState.value).toStrictEqual(dynamicValue);
         expect(cacheState.ttl).toStrictEqual(100);
       });
 
@@ -411,7 +393,7 @@ describe("RunCache", () => {
       const funcToBeExecutedOnRefetchFailure = jest.fn(
         (cacheState: EventParam) => {
           expect(cacheState.key).toStrictEqual(key);
-          expect(cacheState.value).toStrictEqual(JSON.stringify(value));
+          expect(cacheState.value).toStrictEqual(value);
           expect(cacheState.ttl).toStrictEqual(100);
         },
       );

--- a/src/run-cache.test.ts
+++ b/src/run-cache.test.ts
@@ -1,10 +1,6 @@
 import { EVENT, EventParam, RunCache } from "./run-cache";
 import { v4 as uuid } from "uuid";
 
-async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 describe("RunCache", () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -297,12 +293,9 @@ describe("RunCache", () => {
     });
 
     it("should not call sourceFn more than once at a time", async () => {
-      jest.useRealTimers();
-
       const key = uuid();
 
       const sourceFn = jest.fn(async () => {
-        await sleep(10);
         return uuid();
       });
 

--- a/src/run-cache.test.ts
+++ b/src/run-cache.test.ts
@@ -22,43 +22,47 @@ describe("RunCache", () => {
   describe("set()", () => {
     it("should throw an error if the cache key or value is empty", async () => {
       await expect(() =>
-        RunCache.set({ key: "", value: "value1" }),
+        RunCache.set({ key: "", value: uuid() }),
       ).rejects.toThrow("Empty key");
       await expect(() =>
-        RunCache.set({ key: "key1", value: "" }),
+        RunCache.set({ key: uuid(), value: "" }),
       ).rejects.toThrow("`value` can't be empty without a `sourceFn`");
     });
 
     it("should throw an error when a negative ttl is provided", async () => {
       await expect(
         RunCache.set({
-          key: "key1",
-          value: "value1",
+          key: uuid(),
+          value: uuid(),
           ttl: -1,
         }),
       ).rejects.toThrow("`ttl` cannot be negative");
     });
 
     it("should throw an error when the source function throws an error", async () => {
+      const key = uuid();
+
       const sourceFn = jest.fn(async () => {
         throw Error("Unexpected Error");
       });
       await expect(
         RunCache.set({
-          key: "key1",
+          key,
           sourceFn,
         }),
-      ).rejects.toThrow("Source function failed for key: 'key1'");
+      ).rejects.toThrow(`Source function failed for key: '${key}'`);
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
     });
 
     it("should throw an error when the autoRefetch: true while ttl is not provided", async () => {
-      const sourceFn = jest.fn(async () => "dynamicValue");
+      const key = uuid();
+
+      const sourceFn = jest.fn(async () => uuid());
 
       await expect(
         RunCache.set({
-          key: "key2",
+          key,
           sourceFn,
           autoRefetch: true,
         }),
@@ -68,44 +72,53 @@ describe("RunCache", () => {
     });
 
     it("should be able to set a value with source function successfully", async () => {
-      const sourceFn = jest.fn(async () => "dynamicValue");
+      const key = uuid();
+      const value = uuid();
+
+      const sourceFn = jest.fn(() => value);
 
       await RunCache.set({
-        key: "key2",
+        key,
         sourceFn,
       });
-      expect(await RunCache.get("key2")).toBe(JSON.stringify("dynamicValue"));
+      expect(await RunCache.get(key)).toStrictEqual(JSON.stringify(value));
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
     });
 
     it("should be able to set a value with source function, autoRefetch enabled successfully", async () => {
-      const sourceFn = jest.fn(async () => "dynamicValue");
+      const key = uuid();
+      const value = uuid();
+
+      const sourceFn = jest.fn(() => value);
 
       await RunCache.set({
-        key: "key2",
+        key,
         sourceFn,
         ttl: 100,
         autoRefetch: true,
       });
-      expect(await RunCache.get("key2")).toBe(JSON.stringify("dynamicValue"));
+      expect(await RunCache.get(key)).toStrictEqual(JSON.stringify(value));
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
     });
 
     it("should return true if the cache value set successfully", async () => {
-      expect(await RunCache.set({ key: "key1", value: "value1" })).toBe(true);
+      expect(await RunCache.set({ key: uuid(), value: uuid() })).toStrictEqual(
+        true,
+      );
     });
 
     it("should return true if the cache set with a ttl and ttl is functioning properly", async () => {
-      expect(
-        await RunCache.set({ key: "key2", value: "value2", ttl: 100 }),
-      ).toBe(true);
-      expect(await RunCache.get("key2")).toBe(JSON.stringify("value2"));
+      const key = uuid();
+      const value = uuid();
+
+      expect(await RunCache.set({ key, value, ttl: 100 })).toStrictEqual(true);
+      expect(await RunCache.get(key)).toStrictEqual(JSON.stringify(value));
 
       jest.advanceTimersByTime(101);
 
-      expect(await RunCache.get("key2")).toBeUndefined();
+      expect(await RunCache.get(key)).toBeUndefined();
     });
   });
 
@@ -115,32 +128,34 @@ describe("RunCache", () => {
     });
 
     it("should return undefined if the key is not found", async () => {
-      expect(await RunCache.get("key1")).toBeUndefined();
+      expect(await RunCache.get(uuid())).toBeUndefined();
     });
 
     it("should return the value successfully if the cache is not expired", async () => {
-      const sourceFn = jest.fn(() => "value1");
+      const key = uuid();
+      const value = uuid();
+
+      const sourceFn = jest.fn(() => value);
 
       await RunCache.set({
-        key: "key1",
+        key,
         sourceFn,
         ttl: 100,
       });
 
-      expect(await RunCache.get("key1")).toStrictEqual(
-        JSON.stringify("value1"),
-      );
+      expect(await RunCache.get(key)).toStrictEqual(JSON.stringify(value));
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
     });
 
     it("should auto refetch and return the new value successfully", async () => {
-      let dynamicValue = "initialValue";
+      const key = uuid();
+      let dynamicValue = uuid();
 
       const sourceFn = jest.fn(async () => dynamicValue);
 
       await RunCache.set({
-        key: "key2",
+        key,
         sourceFn,
         autoRefetch: true,
         ttl: 100,
@@ -148,74 +163,98 @@ describe("RunCache", () => {
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
 
-      expect(await RunCache.get("key2")).toBe(JSON.stringify("initialValue"));
+      expect(await RunCache.get(key)).toStrictEqual(
+        JSON.stringify(dynamicValue),
+      );
 
-      dynamicValue = "updatedValue";
+      dynamicValue = uuid();
 
       jest.advanceTimersByTime(101);
 
-      expect(await RunCache.get("key2")).toBe(JSON.stringify("updatedValue"));
+      expect(await RunCache.get(key)).toStrictEqual(
+        JSON.stringify(dynamicValue),
+      );
 
       expect(sourceFn).toHaveBeenCalledTimes(2);
     });
 
     it("should return the value successfully", async () => {
-      RunCache.set({ key: "key3", value: "value1" });
-      expect(await RunCache.get("key3")).toBe(JSON.stringify("value1"));
+      const key = uuid();
+      const value = uuid();
+
+      RunCache.set({ key, value });
+      expect(await RunCache.get(key)).toStrictEqual(JSON.stringify(value));
     });
   });
 
   describe("delete()", () => {
     it("should return false if the operation failed", () => {
-      expect(RunCache.delete("nonExistentKey")).toBe(false);
+      expect(RunCache.delete("NonExistentKey")).toStrictEqual(false);
     });
 
     it("should return true if the value is successfully deleted", async () => {
-      RunCache.set({ key: "key1", value: "value1" });
-      expect(RunCache.delete("key1")).toBe(true);
-      expect(await RunCache.get("key1")).toBeUndefined();
+      const key = uuid();
+      const value = uuid();
+
+      RunCache.set({ key, value });
+      expect(RunCache.delete(key)).toStrictEqual(true);
+      expect(await RunCache.get(key)).toBeUndefined();
     });
   });
 
   describe("deleteAll()", () => {
     it("should clear all values", async () => {
-      RunCache.set({ key: "key1", value: "value1" });
-      RunCache.set({ key: "key2", value: "value2" });
+      const key1 = uuid();
+      const key2 = uuid();
+      const value1 = uuid();
+      const value2 = uuid();
+
+      RunCache.set({ key: key1, value: value1 });
+      RunCache.set({ key: key2, value: value2 });
       RunCache.deleteAll();
-      expect(await RunCache.get("key1")).toBeUndefined();
-      expect(await RunCache.get("key2")).toBeUndefined();
+      expect(await RunCache.get(key1)).toBeUndefined();
+      expect(await RunCache.get(key2)).toBeUndefined();
     });
   });
 
   describe("has()", () => {
     it("should return true if the key exists", async () => {
-      RunCache.set({ key: "key1", value: "value1" });
-      expect(await RunCache.has("key1")).toBe(true);
+      const key = uuid();
+      const value = uuid();
+
+      RunCache.set({ key, value });
+      expect(await RunCache.has(key)).toStrictEqual(true);
     });
 
     it("should return false if the key exists", async () => {
-      expect(await RunCache.has("nonExistentKey")).toBe(false);
+      expect(await RunCache.has("NonExistentKey")).toStrictEqual(false);
     });
 
     it("should return false after ttl expiry", async () => {
-      RunCache.set({ key: "key2", value: "value2", ttl: 100 });
-      expect(await RunCache.has("key2")).toBe(true);
+      const key = uuid();
+      const value = uuid();
+
+      RunCache.set({ key, value, ttl: 100 });
+      expect(await RunCache.has(key)).toStrictEqual(true);
 
       jest.advanceTimersByTime(101);
 
-      expect(await RunCache.has("key2")).toBe(false);
+      expect(await RunCache.has(key)).toStrictEqual(false);
     });
   });
 
   describe("refetch()", () => {
     it("should throw an error if refetch is called on a key having no source function", async () => {
-      RunCache.set({ key: "key2", value: "value2" });
-      await expect(RunCache.refetch("key2")).rejects.toThrow(
-        `No source function found for key: 'key2'`,
+      const key = uuid();
+
+      RunCache.set({ key, value: uuid() });
+      await expect(RunCache.refetch(key)).rejects.toThrow(
+        `No source function found for key: '${key}'`,
       );
     });
 
     it("should throw an error when the source function throws an error", async () => {
+      const key = uuid();
       let shouldThrowError = false;
 
       const sourceFn = jest.fn(async () => {
@@ -225,63 +264,72 @@ describe("RunCache", () => {
           return "SomeValue";
         }
       });
-      await RunCache.set({ key: "key3", sourceFn });
+      await RunCache.set({ key, sourceFn });
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
 
       // Make source function to fail
       shouldThrowError = true;
 
-      expect(RunCache.refetch("key3")).rejects.toThrow(
-        "Source function failed for key: 'key3'",
+      expect(RunCache.refetch(key)).rejects.toThrow(
+        `Source function failed for key: '${key}'`,
       );
 
       expect(sourceFn).toHaveBeenCalledTimes(2);
     });
 
     it("should not refetch if the key does not exist", async () => {
-      await expect(RunCache.refetch("nonExistentKey")).resolves.toBeFalsy();
+      await expect(RunCache.refetch("NonExistentKey")).resolves.toStrictEqual(
+        false,
+      );
     });
 
     it("should not call sourceFn more than once at a time", async () => {
       jest.useRealTimers();
 
+      const key = uuid();
+
       const sourceFn = jest.fn(async () => {
         await sleep(10);
-        return "value";
+        return uuid();
       });
 
-      await RunCache.set({ key: "key1", value: "value1", sourceFn });
+      await RunCache.set({ key, value: uuid(), sourceFn });
 
       const [firstRefetch, secondRefetch, thirdRefetch] = await Promise.all([
-        RunCache.refetch("key1"),
-        RunCache.refetch("key1"),
-        RunCache.refetch("key1"),
+        RunCache.refetch(key),
+        RunCache.refetch(key),
+        RunCache.refetch(key),
       ]);
 
-      expect(firstRefetch).toBeTruthy();
-      expect(secondRefetch).toBeFalsy();
-      expect(thirdRefetch).toBeFalsy();
+      expect(firstRefetch).toStrictEqual(true);
+      expect(secondRefetch).toStrictEqual(false);
+      expect(thirdRefetch).toStrictEqual(false);
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
     });
 
     it("should refetch and update the value from the source function", async () => {
-      let dynamicValue = "initialValue";
+      const key = uuid();
+      let dynamicValue = uuid();
       const sourceFn = jest.fn(() => dynamicValue);
 
-      await RunCache.set({ key: "key1", sourceFn });
-      expect(await RunCache.get("key1")).toBe(JSON.stringify("initialValue"));
+      await RunCache.set({ key, sourceFn });
+      expect(await RunCache.get(key)).toStrictEqual(
+        JSON.stringify(dynamicValue),
+      );
 
       expect(sourceFn).toHaveBeenCalledTimes(1);
 
-      dynamicValue = "updatedValue";
+      dynamicValue = uuid();
 
-      await RunCache.refetch("key1");
+      await RunCache.refetch(key);
 
       expect(sourceFn).toHaveBeenCalledTimes(2);
 
-      expect(await RunCache.get("key1")).toBe(JSON.stringify("updatedValue"));
+      expect(await RunCache.get(key)).toStrictEqual(
+        JSON.stringify(dynamicValue),
+      );
     });
   });
 
@@ -294,9 +342,9 @@ describe("RunCache", () => {
 
       const funcToBeExecutedOnExpiry = jest.fn(
         async (cacheState: EventParam) => {
-          expect(cacheState.key).toBe(key);
-          expect(cacheState.value).toBe(JSON.stringify(value));
-          expect(cacheState.ttl).toBe(100);
+          expect(cacheState.key).toStrictEqual(key);
+          expect(cacheState.value).toStrictEqual(JSON.stringify(value));
+          expect(cacheState.ttl).toStrictEqual(100);
         },
       );
 
@@ -304,7 +352,7 @@ describe("RunCache", () => {
       RunCache.onKeyExpiry(key, funcToBeExecutedOnExpiry);
 
       RunCache.set({
-        key: key,
+        key,
         value: JSON.stringify(value),
         ttl: 100,
       });
@@ -322,12 +370,12 @@ describe("RunCache", () => {
 
       const key = uuid();
 
-      let dynamicValue = "FirstValue";
+      let dynamicValue = uuid();
 
       const funcToBeExecutedOnRefetch = jest.fn((cacheState: EventParam) => {
-        expect(cacheState.key).toBe(key);
-        expect(cacheState.value).toBe(JSON.stringify("SecondValue"));
-        expect(cacheState.ttl).toBe(100);
+        expect(cacheState.key).toStrictEqual(key);
+        expect(cacheState.value).toStrictEqual(JSON.stringify(dynamicValue));
+        expect(cacheState.ttl).toStrictEqual(100);
       });
 
       const sourceFn = jest.fn(() => dynamicValue);
@@ -336,19 +384,120 @@ describe("RunCache", () => {
       RunCache.onKeyRefetch(key, funcToBeExecutedOnRefetch);
 
       await RunCache.set({
-        key: key,
+        key,
         sourceFn,
         ttl: 100,
         autoRefetch: true,
       });
 
-      dynamicValue = "SecondValue";
+      dynamicValue = uuid();
 
       jest.advanceTimersByTime(101);
 
       await Promise.resolve(); // Flush microtasks
 
       expect(sourceFn).toHaveBeenCalledTimes(2);
+      expect(funcToBeExecutedOnRefetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("clearEventListeners()", () => {
+    it("should cancel existing all listeners", async () => {
+      const key = uuid();
+
+      const funcToBeExecutedOnRefetch = jest.fn();
+      const funcToBeExecutedOnExpiry = jest.fn();
+
+      const sourceFn = jest.fn(() => "value");
+
+      RunCache.onRefetch(funcToBeExecutedOnRefetch);
+      RunCache.onKeyRefetch(key, funcToBeExecutedOnRefetch);
+
+      RunCache.onExpiry(funcToBeExecutedOnExpiry);
+      RunCache.onKeyExpiry(key, funcToBeExecutedOnExpiry);
+
+      await RunCache.set({
+        key,
+        sourceFn,
+        ttl: 100,
+        autoRefetch: true,
+      });
+
+      const eventsCleared = RunCache.clearEventListeners();
+      expect(eventsCleared).toBeTruthy();
+
+      jest.advanceTimersByTime(101);
+      await Promise.resolve(); // Flush microtasks
+
+      expect(sourceFn).toHaveBeenCalledTimes(2);
+      expect(funcToBeExecutedOnExpiry).toHaveBeenCalledTimes(0);
+      expect(funcToBeExecutedOnRefetch).toHaveBeenCalledTimes(0);
+    });
+
+    it("should cancel existing listeners for a specific event", async () => {
+      const key = uuid();
+
+      const funcToBeExecutedOnRefetch = jest.fn();
+      const funcToBeExecutedOnExpiry = jest.fn();
+
+      const sourceFn = jest.fn(() => "value");
+
+      RunCache.onRefetch(funcToBeExecutedOnRefetch);
+      RunCache.onKeyRefetch(key, funcToBeExecutedOnRefetch);
+
+      RunCache.onExpiry(funcToBeExecutedOnExpiry);
+      RunCache.onKeyExpiry(key, funcToBeExecutedOnExpiry);
+
+      await RunCache.set({
+        key,
+        sourceFn,
+        ttl: 100,
+        autoRefetch: true,
+      });
+
+      const eventsCleared = RunCache.clearEventListeners({ event: "expire" });
+      expect(eventsCleared).toBeTruthy();
+
+      jest.advanceTimersByTime(101);
+      await Promise.resolve(); // Flush microtasks
+
+      expect(sourceFn).toHaveBeenCalledTimes(2);
+      expect(funcToBeExecutedOnExpiry).toHaveBeenCalledTimes(0);
+      expect(funcToBeExecutedOnRefetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("should cancel existing listeners for a specific event key", async () => {
+      const key = uuid();
+
+      const funcToBeExecutedOnRefetch = jest.fn();
+      const funcToBeExecutedOnExpiry = jest.fn();
+
+      const sourceFn = jest.fn(() => "value");
+
+      RunCache.onRefetch(funcToBeExecutedOnRefetch);
+      RunCache.onKeyRefetch(key, funcToBeExecutedOnRefetch);
+
+      RunCache.onExpiry(funcToBeExecutedOnExpiry);
+      RunCache.onKeyExpiry(key, funcToBeExecutedOnExpiry);
+
+      const eventsCleared = RunCache.clearEventListeners({
+        event: "expire",
+        key,
+      });
+      expect(eventsCleared).toBeTruthy();
+
+      await RunCache.set({
+        key,
+        sourceFn,
+        ttl: 100,
+        autoRefetch: true,
+      });
+
+      jest.advanceTimersByTime(101);
+      await Promise.resolve(); // Flush microtasks
+
+      expect(sourceFn).toHaveBeenCalledTimes(2);
+      expect(funcToBeExecutedOnExpiry).toHaveBeenCalledTimes(1);
       expect(funcToBeExecutedOnRefetch).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/run-cache.test.ts
+++ b/src/run-cache.test.ts
@@ -9,7 +9,7 @@ describe("RunCache", () => {
   beforeEach(() => {
     jest.useFakeTimers();
 
-    RunCache.deleteAll();
+    RunCache.flush();
   });
 
   afterEach(() => {
@@ -202,7 +202,7 @@ describe("RunCache", () => {
     });
   });
 
-  describe("deleteAll()", () => {
+  describe("flush()", () => {
     it("should clear all values", async () => {
       const key1 = uuid();
       const key2 = uuid();
@@ -211,7 +211,7 @@ describe("RunCache", () => {
 
       RunCache.set({ key: key1, value: value1 });
       RunCache.set({ key: key2, value: value2 });
-      RunCache.deleteAll();
+      RunCache.flush();
       expect(await RunCache.get(key1)).toBeUndefined();
       expect(await RunCache.get(key2)).toBeUndefined();
     });

--- a/src/run-cache.ts
+++ b/src/run-cache.ts
@@ -164,7 +164,6 @@ class RunCache {
         ...refetchedCache,
       });
 
-      console.log("refetch emitted", Date.now());
       RunCache.emitEvent("refetch", {
         key,
         value: refetchedCache.value,

--- a/src/run-cache.ts
+++ b/src/run-cache.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "events";
+import { EventEmitter } from "node:events";
 
 type CacheState = {
   value: string;
@@ -88,7 +88,7 @@ class RunCache {
 
       timeout = setTimeout(async () => {
         if (typeof sourceFn === "function" && autoRefetch) {
-          await this.refetch(key);
+          await RunCache.refetch(key);
         }
 
         RunCache.emitEvent("expire", {
@@ -203,7 +203,7 @@ class RunCache {
       return undefined;
     }
 
-    if (!this.isExpired(cached)) {
+    if (!RunCache.isExpired(cached)) {
       return cached.value;
     }
 
@@ -272,7 +272,7 @@ class RunCache {
       return false;
     }
 
-    if (this.isExpired(cached)) {
+    if (RunCache.isExpired(cached)) {
       RunCache.emitEvent("expire", {
         key: key,
         value: cached.value,

--- a/src/run-cache.ts
+++ b/src/run-cache.ts
@@ -265,7 +265,7 @@ class RunCache {
    *
    * @returns {void}
    */
-  static deleteAll(): void {
+  static flush(): void {
     const values = Array.from(RunCache.cache.values());
 
     values.forEach(({ timeout }) => {

--- a/src/run-cache.ts
+++ b/src/run-cache.ts
@@ -420,7 +420,11 @@ class RunCache {
       RunCache.emitter.removeAllListeners(params.event);
 
       RunCache.emitter.eventNames().forEach((eventName) => {
-        if (params.event && typeof eventName === 'string' && eventName.startsWith(params.event)) {
+        if (
+          params.event &&
+          typeof eventName === "string" &&
+          eventName.startsWith(params.event)
+        ) {
           RunCache.emitter.removeAllListeners(eventName);
         }
       });

--- a/src/run-cache.ts
+++ b/src/run-cache.ts
@@ -93,7 +93,7 @@ class RunCache {
 
         RunCache.emitEvent("expire", {
           key,
-          value: value!,
+          value: value ?? "",
           ttl,
           createAt: time,
           updateAt: time,
@@ -116,7 +116,7 @@ class RunCache {
       ttl,
       sourceFn,
       autoRefetch,
-      timeout: ttl ? timeout! : undefined,
+      timeout: timeout ?? undefined,
       createAt: time,
       updateAt: time,
     });
@@ -318,11 +318,31 @@ class RunCache {
     RunCache.emitter.on(`refetch-${key}`, callback);
   }
 
-  static clearEventListeners(
-    event: "expire" | "refetch" | undefined = undefined,
-    key: string | undefined = undefined,
-  ) {
-    RunCache.emitter.removeAllListeners();
+  // TODO: Add tests
+  static clearEventListeners(params?: {
+    event?: "expire" | "refetch" | undefined;
+    key?: string | undefined;
+  }): boolean {
+    if (!params) {
+      RunCache.emitter.removeAllListeners();
+      return true;
+    }
+
+    if (params.key && !params.event) {
+      throw Error("`key` cannot be provided without `event`");
+    }
+
+    if (params.event && params.key) {
+      RunCache.emitter.removeAllListeners(`${params.event}-${params.key}`);
+      return true;
+    }
+
+    if (params.event) {
+      RunCache.emitter.removeAllListeners(params.event);
+      return true;
+    }
+
+    return false;
   }
 }
 

--- a/src/run-cache.ts
+++ b/src/run-cache.ts
@@ -394,13 +394,13 @@ class RunCache {
       RunCache.emitter.removeAllListeners(params.event);
 
       RunCache.eventIds.forEach((eventId) => {
-        if (eventId.startsWith(params.event!)) {
+        if (params.event && eventId.startsWith(params.event)) {
           RunCache.emitter.removeAllListeners(eventId);
         }
       });
 
       RunCache.eventIds = RunCache.eventIds.filter(
-        (eventId) => !eventId.startsWith(params.event!),
+        (eventId) => params.event && !eventId.startsWith(params.event),
       );
 
       return true;

--- a/src/run-cache.ts
+++ b/src/run-cache.ts
@@ -77,7 +77,7 @@ class RunCache {
       throw new Error("Empty key");
     }
 
-    if (!sourceFn && !value) {
+    if (sourceFn === undefined && (value === undefined || !value.length)) {
       throw new Error("`value` can't be empty without a `sourceFn`");
     }
 
@@ -86,6 +86,13 @@ class RunCache {
     }
 
     const time = Date.now();
+
+    // Clear existing timeout if the key already exists
+    const existingCache = RunCache.cache.get(key);
+    if (existingCache && existingCache.timeout) {
+      clearTimeout(existingCache.timeout);
+    }
+
     let timeout: ReturnType<typeof setTimeout> | null = null;
 
     if (ttl !== undefined) {

--- a/src/run-cache.ts
+++ b/src/run-cache.ts
@@ -172,17 +172,17 @@ class RunCache {
         updateAt: Date.now(),
       };
 
+      RunCache.cache.set(key, {
+        ...refetchedCache,
+        fetching: undefined,
+      });
+
       RunCache.emitEvent(EVENT.REFETCH, {
         key,
         value: refetchedCache.value,
         ttl: refetchedCache.ttl,
         createAt: refetchedCache.createAt,
         updateAt: refetchedCache.updateAt,
-      });
-
-      RunCache.cache.set(key, {
-        ...refetchedCache,
-        fetching: undefined,
       });
 
       return true;
@@ -200,7 +200,7 @@ class RunCache {
         updateAt: cached.updateAt,
       });
 
-      throw Error(`Source function failed for key: '${key}'`);
+      throw new Error(`Source function failed for key: '${key}'`);
     }
   }
 

--- a/src/run-cache.ts
+++ b/src/run-cache.ts
@@ -95,7 +95,7 @@ class RunCache {
       timeout = setTimeout(async () => {
         RunCache.emitEvent(EVENT.EXPIRE, {
           key,
-          value: value ?? "",
+          value: JSON.stringify(value ?? ""),
           ttl,
           createAt: time,
           updateAt: time,

--- a/src/run-cache.ts
+++ b/src/run-cache.ts
@@ -89,7 +89,7 @@ class RunCache {
 
     // Clear existing timeout if the key already exists
     const existingCache = RunCache.cache.get(key);
-    if (existingCache && existingCache.timeout) {
+    if (existingCache?.timeout) {
       clearTimeout(existingCache.timeout);
     }
 
@@ -101,7 +101,7 @@ class RunCache {
       timeout = setTimeout(() => {
         RunCache.emitEvent(EVENT.EXPIRE, {
           key,
-          value: JSON.stringify(value ?? ""),
+          value: value ?? "undefined",
           ttl,
           createAt: time,
           updateAt: time,
@@ -126,7 +126,7 @@ class RunCache {
     }
 
     RunCache.cache.set(key, {
-      value: JSON.stringify(cacheValue),
+      value: cacheValue ?? 'undefined',
       ttl,
       sourceFn,
       autoRefetch,
@@ -165,7 +165,7 @@ class RunCache {
       const value = await cached.sourceFn();
 
       const refetchedCache = {
-        value: JSON.stringify(value),
+        value: value,
         ttl: cached.ttl,
         sourceFn: cached.sourceFn,
         createAt: cached.createAt,
@@ -181,15 +181,15 @@ class RunCache {
       });
 
       RunCache.cache.set(key, {
-        fetching: undefined,
         ...refetchedCache,
+        fetching: undefined,
       });
 
       return true;
     } catch (e) {
       RunCache.cache.set(key, {
-        fetching: undefined,
         ...cached,
+        fetching: undefined,
       });
 
       RunCache.emitEvent(EVENT.REFETCH_FAILURE, {

--- a/src/run-cache.ts
+++ b/src/run-cache.ts
@@ -139,7 +139,6 @@ class RunCache {
    *
    * @param {string} key - The cache key.
    * @returns {Promise<boolean>} A promise that resolves to a boolean representing the execution state of the request.
-   * @throws Will throw an error if the source function fails.
    */
   static async refetch(key: string): Promise<boolean> {
     const cached = RunCache.cache.get(key);
@@ -149,7 +148,7 @@ class RunCache {
     }
 
     if (typeof cached.sourceFn === "undefined") {
-      throw Error(`No source function found for key: '${key}'`);
+      return false;
     }
 
     if (cached.fetching) {


### PR DESCRIPTION
Fixes #14
Fixes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an event-driven architecture for cache management in the `RunCache` library, allowing for more flexible handling of cache expiration and refetching events.
	- Added new static methods for registering (`onExpiry`, `onKeyExpiry`, `onRefetch`, `onKeyRefetch`) and clearing event listeners related to cache events.
	- Implemented `clearEventListeners` method for better control over event management.
	- Added `autoRefetch` option in cache settings for automatic updates.

- **Bug Fixes**
	- Corrected minor textual issues in the documentation for improved clarity.

- **Documentation**
	- Updated the README to include new event listeners for cache expiry and refetching, along with examples for better usability.

- **Tests**
	- Enhanced testing for cache expiration and refetching functionalities, improving test performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->